### PR TITLE
Addresses #1: Pie throws panic if iop.proc is nil

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"net/rpc/jsonrpc"
-
-	"github.com/natefinch/pie"
 )
 
 // This function should be called from the master program that wants to run

--- a/pie.go
+++ b/pie.go
@@ -204,9 +204,20 @@ var procTimeout = time.Second
 func (iop ioPipe) closeProc() error {
 	result := make(chan error, 1)
 	go func() { _, err := iop.proc.Wait(); result <- err }()
+
+	// If the process handle no longer exists, return nil
+	// because of how tests work this isn't very clean:
+	switch iop.proc.(type) {
+	case *os.Process:
+		if iop.proc.(*os.Process) == nil {
+			return nil
+		}
+	}
+
 	if err := iop.proc.Signal(os.Interrupt); err != nil {
 		return err
 	}
+
 	select {
 	case err := <-result:
 		return err


### PR DESCRIPTION
Tests pass, but in order to make it work had to use a type check since the os.Process underlying type is masked by an interface. 
